### PR TITLE
Fix submit button: Trigger analysis when missing

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -324,15 +324,29 @@ class ComplianceMonitor {
           return false;
         }
 
-        // v2.6.0 FIX: Blockiere wenn KEINE Analyse vorhanden ODER wenn Warnungen/kritische Daten erkannt
+        // v2.6.0 FIX: Wenn KEINE Analyse vorhanden ODER Warnungen erkannt
         if (!analysis || analysis.status === 'critical' || analysis.status === 'warning') {
+          console.log('[AICC Submit] BLOCKING - Analysis:', analysis ? analysis.status : 'NONE');
+
           // Blockiere den originalen Click
           e.preventDefault();
           e.stopPropagation();
           e.stopImmediatePropagation();
 
-          // Zeige Modal (nur wenn Analyse vorhanden)
-          if (analysis) {
+          // Wenn keine Analyse vorhanden, führe sie jetzt durch
+          if (!analysis) {
+            console.log('[AICC Submit] No analysis found - running analysis...');
+            this.analyzeElement(element).then(() => {
+              const newAnalysis = this.currentAnalysis.get(element);
+              if (newAnalysis && (newAnalysis.status === 'critical' || newAnalysis.status === 'warning')) {
+                this.showWarningModal(newAnalysis, element, submitButton);
+              } else {
+                // Keine Warnungen, sende normal
+                this.simulateSubmit(element);
+              }
+            });
+          } else {
+            // Analyse vorhanden mit Warnungen - zeige Modal
             this.showWarningModal(analysis, element, submitButton);
           }
 


### PR DESCRIPTION
CRITICAL BUG FIX:
- Submit button now triggers analysis when no analysis exists
- Previously only blocked without running analysis
- Now matches Enter key behavior exactly

Technical Details:
- content.js:337-347: Added analyzeElement() call when !analysis
- After analysis, shows modal if warnings found or calls simulateSubmit()
- Added console.log for debugging submit button blocking

This ensures users cannot bypass the compliance check by clicking submit button before analysis completes.