### PR TITLE
fix: Tooltip-Positionierung & verständliche Kategorie-Namen

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -490,6 +490,10 @@ class ComplianceMonitor {
         <circle cx="12" cy="12" r="10" fill="white" opacity="0.3"/>
         <path d="M8 12l3 3 5-5" stroke="white" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
+      <div class="aicc-tooltip aicc-tooltip-safe">
+        <span class="aicc-tooltip-icon">✓</span>
+        <span class="aicc-tooltip-text">Keine sensiblen Daten erkannt</span>
+      </div>
     `;
 
     // Positioniere Badge innerhalb des Input-Feldes
@@ -599,6 +603,9 @@ class ComplianceMonitor {
     // Update ARIA label
     const ariaLabel = this.getAriaLabel(analysis);
     badge.setAttribute('aria-label', ariaLabel);
+
+    // Update Tooltip für In-Field Badge
+    this.updateTooltip(badge, analysis);
   }
 
   /**
@@ -1080,8 +1087,8 @@ class ComplianceMonitor {
     if (count > 0) {
       html += `<span class="aicc-tooltip-count">${count}</span>`;
 
-      // Sammle unique Kategorien
-      const categories = [...new Set(analysis.detections.map(d => d.category))];
+      // Sammle unique Kategorien (nutze 'name' statt 'category' für verständliche deutsche Texte)
+      const categories = [...new Set(analysis.detections.map(d => d.name || d.category))];
       const categoryText = categories.slice(0, 3).join(', ');
 
       if (categoryText) {

--- a/extension/styles/content.css
+++ b/extension/styles/content.css
@@ -240,8 +240,8 @@ body.aicc-modal-open .aicc-overlay-container {
 .aicc-tooltip {
   position: absolute;
   bottom: calc(100% + 12px);
-  left: 50%;
-  transform: translateX(-50%);
+  right: 0;
+  left: auto;
   padding: 12px 16px;
   background: var(--beyonder-midnight);
   color: var(--beyonder-white);
@@ -259,13 +259,12 @@ body.aicc-modal-open .aicc-overlay-container {
   line-height: 1.5;
 }
 
-/* Tooltip Arrow */
+/* Tooltip Arrow - rechts positioniert für Fixed Icon */
 .aicc-tooltip::after {
   content: '';
   position: absolute;
   top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 16px;
   border: 6px solid transparent;
   border-top-color: var(--beyonder-midnight);
 }
@@ -274,7 +273,7 @@ body.aicc-modal-open .aicc-overlay-container {
 .aicc-status-icon:hover .aicc-tooltip {
   opacity: 1;
   visibility: visible;
-  transform: translateX(-50%) translateY(-4px);
+  transform: translateY(-4px);
 }
 
 /* Tooltip variants by status */
@@ -372,6 +371,30 @@ body.aicc-modal-open .aicc-overlay-container {
     0 0 0 1px white,
     0 0 0 2px rgba(16, 30, 53, 0.3),
     0 2px 12px rgba(16, 30, 53, 0.3);
+}
+
+/* Tooltip für In-Field Badge */
+.aicc-infield-badge .aicc-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  right: auto;
+  padding: 8px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.aicc-infield-badge .aicc-tooltip::after {
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+}
+
+.aicc-infield-badge:hover .aicc-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(-4px);
 }
 
 /* Badge status colors */


### PR DESCRIPTION
Behobene Probleme:
1. Fixed Icon (unten rechts): Tooltip rechts-ausgerichtet statt zentriert
   - Tooltip ragte vorher aus dem Browser
   - Jetzt: right: 0, Arrow rechts positioniert

2. In-Field Badge: Tooltip hinzugefügt
   - Badge hatte keinen Hover-Tooltip
   - Jetzt: Zentrierter Tooltip oberhalb des Badges

3. Kategorie-Namen: Verständliche deutsche Texte statt "Pii"
   - Verwendet jetzt d.name statt d.category
   - Zeigt z.B. "Name (KI)", "E-Mail-Adresse" statt "Pii"

Technische Details:
- CSS: .aicc-tooltip rechts-ausgerichtet
- CSS: .aicc-infield-badge .aicc-tooltip zentriert
- JS: generateTooltipContent() nutzt d.name