### PR TITLE
fix: Vollständige Prompt-Extraktion für Validierungsreports (v2.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ---
 
+## [2.9.1] - 2025-11-01
+
+### 🔧 Fix: Vollständige Prompt-Extraktion für Validierungsreports
+
+#### Problem
+Bei langen Prompts (>10k Zeichen) wurde der Text im Validierungsreport durch lazy rendering abgeschnitten. Dies verhinderte eine vollständige Analyse durch Claude zur Validierung der Erkennungen.
+
+#### Lösung
+- **Neue Methode `getFullElementText()`** verwendet `textContent` statt `innerText`
+- `textContent` gibt immer den vollständigen Text zurück, unabhängig vom DOM-Rendering
+- Nur für Report-Generierung verwendet - Detection-Performance unverändert
+
+#### Technische Details
+- `content.js:679-686` - Neue Methode für vollständige Text-Extraktion
+- `content.js:1343` - Report verwendet jetzt `getFullElementText()`
+- Report-Versionsinfo auf v2.9.1 aktualisiert
+
+#### Auswirkung
+✅ Validierungsreports enthalten jetzt **immer den vollständigen Prompt**, auch bei 15k+ Zeichen
+✅ Keine Truncation durch virtuelles Scrolling oder Lazy Loading
+✅ Präzisere Validierung durch Claude möglich
+
+---
+
 ## [2.9.0] - 2025-11-01
 
 ### 🔧 Zentrale Versionsverwaltung
@@ -117,6 +141,62 @@ npm run version:sync
 ```
 
 ---
+
+## [2.9.1] - 2025-11-01
+
+### 🔧 Zentrale Versionsverwaltung
+
+#### Zusammenfassung
+
+Einführung eines zentralen Versionsverwaltungssystems für konsistente Versionierung über alle Dateien hinweg.
+
+#### ✅ Neue Features
+
+**1. Zentrale Version Management** 🎯
+
+- **Single Source of Truth:** `extension/scripts/version.js` ist die zentrale Versionsdefinition
+- **Automatische Synchronisation:** Alle Dateien werden automatisch aktualisiert
+- **Git-Integration:** Unterstützt Git-Tags für Versionierung
+- **Build-Script:** `scripts/update-version.js` verwaltet den Prozess
+
+**2. NPM-Scripts für Versionierung** ⚙️
+
+- `npm run version:patch` - Bugfixes (2.9.0 → 2.9.1)
+- `npm run version:minor` - Neue Features (2.9.0 → 2.10.0)
+- `npm run version:major` - Breaking Changes (2.9.0 → 3.0.0)
+- `npm run version:sync` - Synchronisiert aktuelle Version
+
+**3. Aktualisierte Dateien** 📝
+
+- `extension/manifest.json` - Chrome Extension Version
+- `package.json` - NPM Package Version
+- `extension/popup.html` - Angezeigter Version String
+- `extension/scripts/version.js` - Zentrale Versionsdefinition
+- `README.md` - Dokumentierte Version
+- `CHANGELOG.md` - Automatischer Versions-Eintrag
+
+#### 📊 Technische Details
+
+- **Semantic Versioning:** MAJOR.MINOR.PATCH Format
+- **Konsistenz:** Alle Dateien nutzen dieselbe Version
+- **Automatisierung:** Ein Kommando aktualisiert alles
+- **Fehlerprävention:** Keine manuelle Copy-Paste Fehler mehr
+
+#### 🎨 Workflow-Verbesserungen
+
+1. Entwickler führt `npm run version:minor` aus
+2. Script erhöht Version und aktualisiert alle Dateien
+3. `npm run build` erstellt Bundle mit neuer Version
+4. Git Commit & Push
+5. Extension in Chrome zeigt korrekte Version
+
+**Benefits:**
+- ✅ Konsistente Versionierung
+- ✅ Fehlerfreie Synchronisation
+- ✅ Einfacher Workflow
+- ✅ Git-freundlich
+
+
 
 ## [2.8.0] - 2025-11-01
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛡️ AI Compliance Checker - Chrome Browser Extension
 
-**Version 2.9.0** • by BEYONDER
+**Version 2.9.1** • by BEYONDER
 
 Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteingaben in Echtzeit auf personenbezogene, sensible und firmenspezifische Daten prüft.
 
@@ -15,7 +15,30 @@ Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteinga
 
 > **💡 Vollständige Änderungshistorie**: Siehe [CHANGELOG.md](./CHANGELOG.md)
 
-### Version 2.9.0 (Aktuell) - 2025-11-01
+### Version 2.9.1 (Aktuell) - 2025-11-01
+
+**🔧 Fix: Vollständige Prompt-Extraktion für Validierungsreports**
+
+#### 🐛 Problem gelöst
+- **Lange Prompts wurden abgeschnitten:** Bei Prompts >10k Zeichen zeigte der Validierungsreport nur einen Teil des Textes
+- **Ursache:** `innerText` gibt nur gerenderten/sichtbaren Text zurück (lazy rendering Problem)
+- **Auswirkung:** Claude konnte nicht alle Erkennungen vollständig validieren
+
+#### ✅ Lösung
+- **Neue Methode `getFullElementText()`:** Verwendet `textContent` statt `innerText`
+- **Garantiert vollständiger Text:** Unabhängig von DOM-Rendering oder virtuellem Scrolling
+- **Nur für Reports:** Detection-Performance bleibt unverändert (weiterhin schnell)
+
+#### 🎯 Auswirkung
+- ✅ Reports enthalten **vollständigen Prompt** (auch bei 15k+ Zeichen)
+- ✅ Keine Truncation durch Browser-Optimierungen
+- ✅ Präzisere Validierung durch Claude möglich
+
+> **📖 Details**: Siehe [CHANGELOG.md](./CHANGELOG.md#291---2025-11-01)
+
+---
+
+### Version 2.9.0 (Vorherige) - 2025-11-01
 
 **🔧 Zentrale Versionsverwaltung**
 
@@ -892,4 +915,4 @@ Bei Fragen, Problemen oder Feedback:
 
 **Made with ❤️ for Privacy & Compliance by BEYONDER**
 
-**Version 2.9.0** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Enhanced Icon Visibility & Hybrid Approach!
+**Version 2.9.1** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Enhanced Icon Visibility & Hybrid Approach!

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Compliance Checker",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Schützt Ihre sensiblen Daten bei ChatGPT, Claude & Gemini. Erkennt Namen, Geburtsdaten, Standorte, Geldbeträge, Organisationen, E-Mails, IBAN uvm. 100% lokal, DSGVO-konform.",
   "permissions": [
     "storage"

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -569,7 +569,7 @@
       DSGVO & DSG konform • 100% lokal • Keine Telemetrie
     </div>
     <div class="version">
-      Version 2.9.0 BETA
+      Version 2.9.1 BETA
     </div>
   </div>
 

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -672,6 +672,20 @@ class ComplianceMonitor {
   }
 
   /**
+   * v2.9.1: Holt VOLLSTÄNDIGEN Text aus Element für Report-Zwecke
+   * Verwendet textContent ZUERST um Truncation durch lazy rendering zu vermeiden
+   * Besonders wichtig für lange Prompts (>10k Zeichen) bei Claude.ai/ChatGPT
+   */
+  getFullElementText(element) {
+    if (element.contentEditable === 'true') {
+      // textContent gibt IMMER den kompletten Text zurück, unabhängig vom Rendering
+      // Bei virtuellen Scrolling/Lazy Loading werden sonst Teile abgeschnitten
+      return element.textContent || element.innerText || '';
+    }
+    return element.value || '';
+  }
+
+  /**
    * v2.3.4: Normalisiert Text mit Leerzeichen zwischen Block-Elementen
    * Verhindert Wort-Zusammenführung wie bei innerText, aber behält Offset-Konsistenz
    */
@@ -1319,12 +1333,14 @@ class ComplianceMonitor {
   /**
    * Generiert Validierungs-Report für Claude
    * v2.7.0: Erweitert mit allen Prüfkriterien und vollem Prompt
+   * v2.9.1: Verwendet getFullElementText() für vollständige Prompt-Extraktion
    */
   generateValidationReport(analysis, element = null, isDeveloperMode = true) {
     const lang = this.currentLang;
 
-    // Extrahiere eingegebenen Text (OHNE Kürzung in v2.7.0)
-    const inputText = element ? this.getElementText(element) : '';
+    // v2.9.1: Extrahiere VOLLSTÄNDIGEN Text für Report (textContent statt innerText)
+    // Verhindert Truncation bei langen Prompts (>10k Zeichen) durch lazy rendering
+    const inputText = element ? this.getFullElementText(element) : '';
 
     // v2.7.0: Hole alle verfügbaren Prüfkriterien
     const allCriteria = this.detector.getAllCriteria(lang);
@@ -1340,7 +1356,7 @@ class ComplianceMonitor {
     });
 
     // Erstelle Markdown-Tabelle
-    let report = `# AI Compliance Checker - Validierungsreport v2.7.0
+    let report = `# AI Compliance Checker - Validierungsreport v2.9.1
 
 ## Rolle
 Du bist ein Experte für Datenschutz, DSGVO/DSG-Compliance und PII (Personally Identifiable Information) Erkennung.
@@ -1430,7 +1446,7 @@ ${inputText}
    - Accuracy = ✅ / (✅ + ❌)
 
 ## Kontext
-- **Tool**: AI Compliance Checker v2.7.0
+- **Tool**: AI Compliance Checker v2.9.1
 - **Sprache**: ${lang === 'de' ? 'Deutsch' : 'English'}
 - **Textlänge**: ${inputText.length} Zeichen
 - **Geprüfte Kriterien**: ${allCriteria.critical.length + allCriteria.warning.length} total (${allCriteria.critical.length} kritisch, ${allCriteria.warning.length} Warnungen)

--- a/extension/scripts/version.js
+++ b/extension/scripts/version.js
@@ -5,7 +5,7 @@
  * Update this file when releasing new versions.
  */
 
-export const VERSION = '2.9.0';
+export const VERSION = '2.9.1';
 export const VERSION_LABEL = 'BETA';
 export const VERSION_FULL = `${VERSION} ${VERSION_LABEL}`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-compliance-checker",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Enhanced compliance checker for ChatGPT, Claude, Gemini with Compromise.js NER (ML-quality without ML) - Now with dates, places, money, organizations",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Problem:
- Lange Prompts (>10k Zeichen) wurden im Validierungsreport abgeschnitten
- innerText gibt nur gerenderten/sichtbaren Text zurück (lazy rendering)
- Claude konnte Erkennungen nicht vollständig validieren

Lösung:
- Neue Methode getFullElementText() verwendet textContent statt innerText
- textContent gibt immer vollständigen Text zurück (DOM-unabhängig)
- Nur für Report-Generierung verwendet (Detection-Performance unverändert)

Änderungen:
- content.js:679-686 - Neue getFullElementText() Methode
- content.js:1343 - Report verwendet getFullElementText()
- Versionierung auf 2.9.1 erhöht (manifest.json, package.json, popup.html, version.js)
- CHANGELOG.md und README.md aktualisiert

Impact:
✅ Reports enthalten vollständigen Prompt (auch bei 15k+ Zeichen) ✅ Keine Truncation durch Browser-Optimierungen
✅ Präzisere Validierung durch Claude möglich