### PR TITLE
docs: Update VERSIONING_GUIDE mit --no-verify Warnung

### DIFF
--- a/.claude/docs/VERSIONING_GUIDE.md
+++ b/.claude/docs/VERSIONING_GUIDE.md
@@ -4,6 +4,42 @@
 
 ---
 
+## ⚠️ KRITISCHE REGEL: NIE --no-verify VERWENDEN!
+
+**🚨 NIEMALS `--no-verify` beim Committen verwenden! 🚨**
+
+```bash
+# ❌ FALSCH - Hook wird umgangen, Version wird NICHT erhöht!
+git commit -m "fix: Bug XYZ (v2.9.8)" --no-verify
+
+# ✅ RICHTIG - Hook läuft automatisch, Version wird erhöht
+git commit -m "fix: Bug XYZ"
+```
+
+### Warum ist --no-verify problematisch?
+
+**Problem:** Version-Inkonsistenz zwischen Code und Commit-Message
+
+**Beispiel aus der Praxis (v2.9.5-2.9.8 Incident):**
+```bash
+# Commits mit --no-verify gemacht:
+git commit -m "feat: UX improvements (v2.9.6)" --no-verify
+git commit -m "fix: Icon bug (v2.9.7)" --no-verify
+git commit -m "fix: Syntax error (v2.9.8)" --no-verify
+
+# Resultat:
+# - Commit Messages: v2.9.6, v2.9.7, v2.9.8
+# - Tatsächliche Version in App: 2.9.5 ❌
+# - User sieht falsche Version!
+```
+
+**Lösung:** Pre-Commit Hook IMMER laufen lassen
+- Hook erhöht Version automatisch
+- Alle Dateien werden synchronisiert
+- Garantierte Konsistenz
+
+---
+
 ## 🔑 Grundprinzipien
 
 ### Single Source of Truth
@@ -39,25 +75,40 @@ npm run build
 ### 2. Commit Message Format
 
 ```bash
-git commit -m "<type>: <description> (v<new-version>)"
+git commit -m "<type>: <description>"
 ```
 
+**⚠️ WICHTIG:** Version NICHT in Commit-Message schreiben!
+- Hook erhöht die Version automatisch
+- Du kannst die neue Version NICHT vorhersagen (Hook könnte sie ändern)
+- Nach dem Commit: Prüfe `git log -1` für die tatsächliche Version
+
 **Types:**
-- `fix:` - Bugfixes (Patch)
-- `feat:` - Neue Features (Minor)
+- `fix:` - Bugfixes (Patch → 2.9.8 → 2.9.9)
+- `feat:` - Neue Features (Minor → 2.9.8 → 2.10.0)
 - `refactor:` - Code-Umstrukturierung (Patch)
 - `docs:` - Dokumentation (Patch)
 - `style:` - Styling/Formatierung (Patch)
 - `perf:` - Performance-Verbesserung (Patch)
 - `test:` - Tests (Patch)
 - `chore:` - Wartung/Build (Patch)
-- `BREAKING:` - Breaking Changes (Major)
+- `BREAKING:` - Breaking Changes (Major → 2.9.8 → 3.0.0)
 
 **Beispiele:**
 ```bash
-git commit -m "fix: TypeError bei chrome.storage Zugriff (v2.9.4)"
-git commit -m "feat: Neue Versionierungssystem (v2.10.0)"
-git commit -m "BREAKING: API-Änderung für detector.js (v3.0.0)"
+# ✅ RICHTIG - Keine Version angeben
+git commit -m "fix: TypeError bei chrome.storage Zugriff"
+git commit -m "feat: Globales Icon-System"
+git commit -m "BREAKING: API-Änderung für detector.js"
+
+# ❌ FALSCH - Version angegeben (kann falsch sein!)
+git commit -m "fix: Bug XYZ (v2.9.10)"  # Hook macht v2.9.9!
+```
+
+**Nach dem Commit:**
+```bash
+# Prüfe die tatsächlich verwendete Version:
+git log -1 --oneline
 ```
 
 ### 3. Push
@@ -147,12 +198,55 @@ npm run version:sync
 - [ ] Änderungen funktional getestet?
 - [ ] Build läuft ohne Fehler? (`npm run build`)
 - [ ] **Versionierung erfolgt automatisch durch Pre-Commit Hook**
-- [ ] Commit Message folgt Format: `<type>: <description> (v<version>)`
+- [ ] **🚨 NIE `--no-verify` verwenden!**
+- [ ] Commit Message folgt Format: `<type>: <description>` (OHNE Version!)
 - [ ] Keine manuellen Versionsnummern in Code-Dateien
 
 ---
 
 ## 🐛 Troubleshooting
+
+### Problem: "Commits mit --no-verify gemacht - Version stimmt nicht!"
+
+**Symptome:**
+- Commit Messages sagen v2.9.8, aber App zeigt v2.9.5
+- Mehrere Commits ohne Versionierung
+
+**Diagnose:**
+```bash
+# Prüfe aktuelle Version in allen Dateien
+grep "version" extension/manifest.json
+grep "VERSION =" extension/scripts/version.js
+grep "Version.*BETA" extension/popup.html
+```
+
+**Lösung:**
+```bash
+# 1. Ermittle wie viele Versionen fehlen
+# Beispiel: Commits sagen v2.9.6, v2.9.7, v2.9.8 aber Version ist 2.9.5
+# → 3 Versionen fehlen
+
+# 2. Erhöhe Version entsprechend oft
+npm run version:patch  # 2.9.5 → 2.9.6
+npm run version:patch  # 2.9.6 → 2.9.7
+npm run version:patch  # 2.9.7 → 2.9.8
+
+# 3. Build
+npm run build
+
+# 4. Sync-Commit OHNE --no-verify!
+git add -A
+git commit -m "chore: Sync version to 2.9.8 - fix after --no-verify incident"
+
+# 5. Push
+git push -u origin <branch>
+```
+
+**Prävention:**
+- ❌ NIE MEHR `--no-verify` verwenden!
+- ✅ Immer Hook laufen lassen
+
+---
 
 ### Problem: "Version wurde nicht erhöht"
 **Lösung:**
@@ -213,7 +307,7 @@ Format: **MAJOR.MINOR.PATCH**
 ### Bei jedem Task mit Code-Änderungen:
 
 1. **Vor dem Commit:** Pre-Commit Hook läuft automatisch
-2. **Commit Message:** Erstelle aussagekräftige Message mit Type + Version
+2. **Commit Message:** Erstelle aussagekräftige Message mit Type (OHNE Version!)
 3. **Push:** Mit `-u origin <branch-name>`
 
 ### Beispiel-Workflow:
@@ -222,11 +316,24 @@ Format: **MAJOR.MINOR.PATCH**
 # Änderungen gemacht...
 git add -A
 
-# Commit (Hook erhöht Version automatisch)
-git commit -m "fix: Chrome storage race condition (v2.9.4)"
+# Commit (Hook erhöht Version automatisch - NIE --no-verify!)
+git commit -m "fix: Chrome storage race condition"
 
 # Push
 git push -u origin claude/feature-branch-xyz
+
+# Prüfe die verwendete Version
+git log -1 --oneline
+# Output: abc1234 fix: Chrome storage race condition
+```
+
+**🚨 KRITISCH: NIE `--no-verify` verwenden!**
+```bash
+# ❌ NIEMALS SO:
+git commit -m "fix: Bug" --no-verify
+
+# ✅ IMMER SO:
+git commit -m "fix: Bug"
 ```
 
 ### Ausnahmen:
@@ -244,18 +351,34 @@ git push -u origin claude/feature-branch-xyz
 ### ✅ DO
 
 - Vertraue dem automatischen System
-- Nutze Pre-Commit Hook
+- Nutze Pre-Commit Hook (immer!)
 - Importiere `VERSION` aus `version.js` wenn benötigt
 - Folge SemVer Konventionen
-- Schreibe aussagekräftige Commit Messages
+- Schreibe aussagekräftige Commit Messages (ohne Version!)
+- Prüfe `git log -1` nach Commit für tatsächliche Version
 
 ### ❌ DON'T
 
+- **🚨 NIEMALS `--no-verify` verwenden** (führt zu Inkonsistenzen!)
 - Versionsnummern manuell in Dateien schreiben
 - Versionsnummern in Code-Header-Kommentaren
+- Version in Commit-Message angeben (Hook macht das!)
 - Commits ohne Versionierung
 - Commits ohne Build
 - Force-Push ohne Absprache
+
+### ⚠️ Lessons Learned (v2.9.5-2.9.8 Incident)
+
+**Was passiert ist:**
+- 3 Commits mit `--no-verify` gemacht
+- Commit Messages: v2.9.6, v2.9.7, v2.9.8
+- Tatsächliche Version blieb: 2.9.5
+- User sah falsche Version in der App
+
+**Lösung:**
+- Version manuell 3x erhöht (npm run version:patch)
+- Sync-Commit erstellt
+- **Regel etabliert: NIE MEHR --no-verify!**
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,62 @@ Der Validierungsreport wurde komplett überarbeitet für eine **optimale Analyse
 | # | Kriterium | Wert |
 |---
 
+## [2.9.9] - 2025-11-02
+
+### 🔧 Zentrale Versionsverwaltung
+
+#### Zusammenfassung
+
+Einführung eines zentralen Versionsverwaltungssystems für konsistente Versionierung über alle Dateien hinweg.
+
+#### ✅ Neue Features
+
+**1. Zentrale Version Management** 🎯
+
+- **Single Source of Truth:** `extension/scripts/version.js` ist die zentrale Versionsdefinition
+- **Automatische Synchronisation:** Alle Dateien werden automatisch aktualisiert
+- **Git-Integration:** Unterstützt Git-Tags für Versionierung
+- **Build-Script:** `scripts/update-version.js` verwaltet den Prozess
+
+**2. NPM-Scripts für Versionierung** ⚙️
+
+- `npm run version:patch` - Bugfixes (2.9.0 → 2.9.1)
+- `npm run version:minor` - Neue Features (2.9.0 → 2.10.0)
+- `npm run version:major` - Breaking Changes (2.9.0 → 3.0.0)
+- `npm run version:sync` - Synchronisiert aktuelle Version
+
+**3. Aktualisierte Dateien** 📝
+
+- `extension/manifest.json` - Chrome Extension Version
+- `package.json` - NPM Package Version
+- `extension/popup.html` - Angezeigter Version String
+- `extension/scripts/version.js` - Zentrale Versionsdefinition
+- `README.md` - Dokumentierte Version
+- `CHANGELOG.md` - Automatischer Versions-Eintrag
+
+#### 📊 Technische Details
+
+- **Semantic Versioning:** MAJOR.MINOR.PATCH Format
+- **Konsistenz:** Alle Dateien nutzen dieselbe Version
+- **Automatisierung:** Ein Kommando aktualisiert alles
+- **Fehlerprävention:** Keine manuelle Copy-Paste Fehler mehr
+
+#### 🎨 Workflow-Verbesserungen
+
+1. Entwickler führt `npm run version:minor` aus
+2. Script erhöht Version und aktualisiert alle Dateien
+3. `npm run build` erstellt Bundle mit neuer Version
+4. Git Commit & Push
+5. Extension in Chrome zeigt korrekte Version
+
+**Benefits:**
+- ✅ Konsistente Versionierung
+- ✅ Fehlerfreie Synchronisation
+- ✅ Einfacher Workflow
+- ✅ Git-freundlich
+
+
+
 ## [2.9.8] - 2025-11-02
 
 ### 🔧 Zentrale Versionsverwaltung

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛡️ AI Compliance Checker - Chrome Browser Extension
 
-**Version 2.9.8** • by BEYONDER
+**Version 2.9.9** • by BEYONDER
 
 Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteingaben in Echtzeit auf personenbezogene, sensible und firmenspezifische Daten prüft.
 
@@ -937,4 +937,4 @@ Bei Fragen, Problemen oder Feedback:
 
 **Made with ❤️ for Privacy & Compliance by BEYONDER**
 
-**Version 2.9.8** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Critical Bugfixes & Validation!
+**Version 2.9.9** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Critical Bugfixes & Validation!

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Compliance Checker",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Schützt Ihre sensiblen Daten bei ChatGPT, Claude & Gemini. Erkennt Namen, Geburtsdaten, Standorte, Geldbeträge, Organisationen, E-Mails, IBAN uvm. 100% lokal, DSGVO-konform.",
   "permissions": [
     "storage"

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -569,7 +569,7 @@
       DSGVO & DSG konform • 100% lokal • Keine Telemetrie
     </div>
     <div class="version">
-      Version 2.9.8 BETA
+      Version 2.9.9 BETA
     </div>
   </div>
 

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -1396,7 +1396,7 @@ class ComplianceMonitor {
     allDetections.sort((a, b) => a.start - b.start);
 
     // Erstelle Markdown-Report
-    let report = `# AI Compliance Checker - Validierungsreport v2.9.8
+    let report = `# AI Compliance Checker - Validierungsreport v2.9.9
 
 ## 🎯 Rolle
 Du bist ein Experte für Datenschutz, DSGVO/DSG-Compliance und PII (Personally Identifiable Information) Erkennung.

--- a/extension/scripts/version.js
+++ b/extension/scripts/version.js
@@ -5,7 +5,7 @@
  * Update this file when releasing new versions.
  */
 
-export const VERSION = '2.9.8';
+export const VERSION = '2.9.9';
 export const VERSION_LABEL = 'BETA';
 export const VERSION_FULL = `${VERSION} ${VERSION_LABEL}`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-compliance-checker",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Enhanced compliance checker for ChatGPT, Claude, Gemini with Compromise.js NER (ML-quality without ML) - Now with dates, places, money, organizations",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
✅ Hinzugefügt:
- Kritische Warnung: NIE --no-verify verwenden (ganz oben!)
- Erklärung warum --no-verify problematisch ist
- Real-World Beispiel (v2.9.5-2.9.8 Incident)
- Troubleshooting für --no-verify Probleme
- Lessons Learned Abschnitt
- Aktualisierte Checkliste
- Korrigierte Commit-Message-Beispiele (ohne Version)

🚨 Key Changes:
- Version NICHT in Commit-Message schreiben
- Hook macht automatisch alles
- NIEMALS --no-verify
- Detaillierte Recovery-Anleitung bei Fehlern