### PR TITLE
Fix plugin disable option not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,97 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ---
 
+## [2.10.5] - 2025-11-14
+
+### 🐛 Kritische Bugfixes
+
+#### Plugin-Deaktivierung funktioniert jetzt auf ALLEN Plattformen
+- **Problem behoben**: Deaktivierung wirkte nur auf ChatGPT, nicht auf Claude/Gemini
+- **Root Cause**: Content-Scripts auf bereits geladenen Tabs erhielten Storage-Änderungen nicht
+- **Lösung**: Message Broadcasting an ALLE Tabs bei Toggle-Änderung
+  - `popup.js` sendet jetzt `toggleExtension` Message an alle offenen Tabs
+  - `content.js` lauscht auf Message und reagiert sofort
+  - Extension wird instant deaktiviert/aktiviert (kein Tab-Reload nötig)
+
+#### UI/UX Verbesserung
+- **Toggle-Switch verschoben**: Jetzt direkt neben dem Status-Display
+  - Vorher: Versteckt in Einstellungen weiter unten
+  - Jetzt: Prominent sichtbar direkt beim Status
+  - Bessere Sichtbarkeit und schnellerer Zugriff
+
+#### Interne Bugfixes
+- **`stopMonitoring()` Bug behoben**:
+  - Verwendete nicht-existierende `this.statusIcons` Property
+  - Korrigiert zu `this.globalStatusIcon`
+  - DOM Observer wird jetzt korrekt gestoppt
+  - Alle Overlays und Analysen werden vollständig aufgeräumt
+
+### 🔧 Technische Verbesserungen
+- **Message-basierte Kommunikation** zwischen Popup und Content-Scripts
+- **Globale Monitor-Referenz** ermöglicht dynamisches Start/Stop
+- **Zuverlässigere Deaktivierung** über alle unterstützten Plattformen
+
+### 🧪 Getestet auf
+- ✅ ChatGPT (chat.openai.com, chatgpt.com)
+- ✅ Claude (claude.ai)
+- ✅ Gemini (gemini.google.com)
+
+---
+
+### 🔧 Zentrale Versionsverwaltung
+
+#### Zusammenfassung
+
+Einführung eines zentralen Versionsverwaltungssystems für konsistente Versionierung über alle Dateien hinweg.
+
+#### ✅ Neue Features
+
+**1. Zentrale Version Management** 🎯
+
+- **Single Source of Truth:** `extension/scripts/version.js` ist die zentrale Versionsdefinition
+- **Automatische Synchronisation:** Alle Dateien werden automatisch aktualisiert
+- **Git-Integration:** Unterstützt Git-Tags für Versionierung
+- **Build-Script:** `scripts/update-version.js` verwaltet den Prozess
+
+**2. NPM-Scripts für Versionierung** ⚙️
+
+- `npm run version:patch` - Bugfixes (2.9.0 → 2.9.1)
+- `npm run version:minor` - Neue Features (2.9.0 → 2.10.0)
+- `npm run version:major` - Breaking Changes (2.9.0 → 3.0.0)
+- `npm run version:sync` - Synchronisiert aktuelle Version
+
+**3. Aktualisierte Dateien** 📝
+
+- `extension/manifest.json` - Chrome Extension Version
+- `package.json` - NPM Package Version
+- `extension/popup.html` - Angezeigter Version String
+- `extension/scripts/version.js` - Zentrale Versionsdefinition
+- `README.md` - Dokumentierte Version
+- `CHANGELOG.md` - Automatischer Versions-Eintrag
+
+#### 📊 Technische Details
+
+- **Semantic Versioning:** MAJOR.MINOR.PATCH Format
+- **Konsistenz:** Alle Dateien nutzen dieselbe Version
+- **Automatisierung:** Ein Kommando aktualisiert alles
+- **Fehlerprävention:** Keine manuelle Copy-Paste Fehler mehr
+
+#### 🎨 Workflow-Verbesserungen
+
+1. Entwickler führt `npm run version:minor` aus
+2. Script erhöht Version und aktualisiert alle Dateien
+3. `npm run build` erstellt Bundle mit neuer Version
+4. Git Commit & Push
+5. Extension in Chrome zeigt korrekte Version
+
+**Benefits:**
+- ✅ Konsistente Versionierung
+- ✅ Fehlerfreie Synchronisation
+- ✅ Einfacher Workflow
+- ✅ Git-freundlich
+
+
+
 ## [2.10.4] - 2025-11-03
 
 ### 🔒 DSGVO-Compliance: Kritische Datenschutz-Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛡️ AI Compliance Checker - Chrome Browser Extension
 
-**Version 2.10.4** • by BEYONDER
+**Version 2.10.5** • by BEYONDER
 
 Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteingaben in Echtzeit auf personenbezogene, sensible und firmenspezifische Daten prüft.
 
@@ -15,7 +15,22 @@ Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteinga
 
 > **💡 Vollständige Änderungshistorie**: Siehe [CHANGELOG.md](./CHANGELOG.md)
 
-### Version 2.10.4 (Aktuell) - 2025-11-03
+### Version 2.10.5 (Aktuell) - 2025-11-14
+
+**🐛 Kritische Bugfixes: Plugin-Deaktivierung & UI-Verbesserung**
+
+#### 🚀 Fixes
+- **Plugin-Deaktivierung wirkt jetzt auf ALLEN Plattformen** (ChatGPT, Claude, Gemini)
+  - Problem behoben: Deaktivierung funktionierte nur auf ChatGPT
+  - Lösung: Message Broadcasting an alle Tabs + sofortige Reaktion
+- **Toggle-Switch verschoben**: Jetzt direkt neben Status-Display für bessere Sichtbarkeit
+- **Instant-Deaktivierung**: Kein Tab-Reload mehr nötig
+
+> **📖 Details**: Siehe [CHANGELOG.md](./CHANGELOG.md#2105---2025-11-14)
+
+---
+
+### Version 2.10.4 (Vorherige) - 2025-11-03
 
 **🎨 UX-Optimierung: Modales Feedback-Formular**
 
@@ -29,7 +44,7 @@ Ein lokaler KI-gestützter Compliance-Checker für KI-Plattformen, der Texteinga
 
 ---
 
-### Version 2.10.3 (Vorherige) - 2025-11-03
+### Version 2.10.3 - 2025-11-03
 
 **🎨 UX/Lesbarkeit Verbesserungen (Feedback-System)**
 
@@ -990,4 +1005,4 @@ Bei Fragen, Problemen oder Feedback:
 
 **Made with ❤️ for Privacy & Compliance by BEYONDER**
 
-**Version 2.10.4** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Critical Bugfixes & Validation!
+**Version 2.10.5** - Powered by [Compromise.js](https://github.com/spencermountain/compromise) - Critical Bugfixes & Validation!

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Compliance Checker",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Schützt Ihre sensiblen Daten bei ChatGPT, Claude & Gemini. Erkennt Namen, Geburtsdaten, Standorte, Geldbeträge, Organisationen, E-Mails, IBAN uvm. 100% lokal, DSGVO-konform.",
   "permissions": [
     "storage",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -466,6 +466,10 @@
         <h3 id="status-title">Aktiv & Überwacht</h3>
         <p id="status-description">Extension läuft im Hintergrund</p>
       </div>
+      <label class="toggle-switch">
+        <input type="checkbox" id="extension-enabled-toggle" checked>
+        <span class="toggle-slider"></span>
+      </label>
     </div>
 
     <div class="divider"></div>
@@ -547,16 +551,6 @@
     <div class="section">
       <h2>⚙️ Einstellungen</h2>
       <div class="settings-box">
-        <div class="setting-item" style="margin-bottom: 20px;">
-          <div class="setting-info">
-            <h4>🛡️ Extension aktiviert</h4>
-            <p>Extension ein- oder ausschalten (Standard: aktiviert)</p>
-          </div>
-          <label class="toggle-switch">
-            <input type="checkbox" id="extension-enabled-toggle" checked>
-            <span class="toggle-slider"></span>
-          </label>
-        </div>
         <div class="setting-item">
           <div class="setting-info">
             <h4>🔧 Entwicklermodus</h4>
@@ -609,7 +603,7 @@
       DSGVO & DSG konform • 100% lokal • Keine Telemetrie
     </div>
     <div class="version">
-      Version 2.10.4 BETA
+      Version 2.10.5 BETA
     </div>
   </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -42,18 +42,28 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Update Status Display
         updateStatusDisplay(isEnabled);
 
-        // Visual feedback
-        const settingInfo = extensionEnabledToggle.closest('.setting-item').querySelector('.setting-info p');
-        const originalText = settingInfo.textContent;
-        settingInfo.textContent = isEnabled
-          ? '✅ Extension aktiviert - Überwachung läuft'
-          : '✅ Extension deaktiviert';
-        settingInfo.style.color = 'var(--status-ok)';
+        // CRITICAL: Broadcast to ALL tabs (not just active tab)
+        // This ensures instant deactivation across all platforms
+        const tabs = await chrome.tabs.query({});
+        console.log('[AI Compliance Checker] Broadcasting extension state to', tabs.length, 'tabs');
 
-        setTimeout(() => {
-          settingInfo.textContent = originalText;
-          settingInfo.style.color = '';
-        }, 2000);
+        for (const tab of tabs) {
+          // Skip tabs without valid URL (chrome://, edge://, etc.)
+          if (!tab.url || tab.url.startsWith('chrome://') || tab.url.startsWith('edge://')) {
+            continue;
+          }
+
+          try {
+            await chrome.tabs.sendMessage(tab.id, {
+              action: 'toggleExtension',
+              enabled: isEnabled
+            });
+          } catch (err) {
+            // Tab might not have content script loaded, ignore
+            console.debug('[AI Compliance Checker] Could not send message to tab', tab.id, err.message);
+          }
+        }
+
       } catch (error) {
         console.error('[AI Compliance Checker] Error saving settings:', error);
       }

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -88,13 +88,11 @@ class ComplianceMonitor {
   stopMonitoring() {
     console.log('[AI Compliance Checker] Stopping monitoring...');
 
-    // Entferne alle Status-Icons
-    this.statusIcons.forEach((iconWrapper) => {
-      if (iconWrapper && iconWrapper.parentNode) {
-        iconWrapper.parentNode.removeChild(iconWrapper);
-      }
-    });
-    this.statusIcons.clear();
+    // Entferne globales Status-Icon
+    if (this.globalStatusIcon && this.globalStatusIcon.parentNode) {
+      this.globalStatusIcon.parentNode.removeChild(this.globalStatusIcon);
+      this.globalStatusIcon = null;
+    }
 
     // Entferne alle Overlays
     this.overlayContainers.forEach((container) => {
@@ -104,11 +102,20 @@ class ComplianceMonitor {
     });
     this.overlayContainers.clear();
 
+    // Stoppe DOM Observer
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
     // Entferne Event Listener von monitored elements
     this.monitoredElements.forEach((listeners, element) => {
       // Event Listener werden automatisch entfernt wenn Element nicht mehr referenziert wird
     });
     this.monitoredElements.clear();
+
+    // Leere alle Analysen
+    this.currentAnalysis.clear();
 
     console.log('[AI Compliance Checker] Monitoring stopped');
   }
@@ -1469,7 +1476,7 @@ class ComplianceMonitor {
     allDetections.sort((a, b) => a.start - b.start);
 
     // Erstelle Markdown-Report
-    let report = `# AI Compliance Checker - Validierungsreport v2.10.4
+    let report = `# AI Compliance Checker - Validierungsreport v2.10.5
 
 ## 🎯 Rolle
 Du bist ein Experte für Datenschutz, DSGVO/DSG-Compliance und PII (Personally Identifiable Information) Erkennung.
@@ -1985,18 +1992,21 @@ Prüfe ob folgende Kategorien übersehen wurden:
   }
 }
 
+// Global reference to monitor for dynamic enable/disable
+let complianceMonitor = null;
+
 // Starte Monitor wenn Seite geladen ist
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    new ComplianceMonitor();
+    complianceMonitor = new ComplianceMonitor();
   });
 } else {
-  new ComplianceMonitor();
+  complianceMonitor = new ComplianceMonitor();
 }
 
 /**
- * Message Listener für Feedback-System
- * Empfängt Messages von Popup und öffnet Feedback-Modal
+ * Message Listener für Feedback-System & Extension Toggle
+ * Empfängt Messages von Popup und öffnet Feedback-Modal oder toggle Extension
  */
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'openFeedbackModal') {
@@ -2008,6 +2018,33 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ success: true });
     } catch (error) {
       console.error('[AI Compliance Checker] Error opening feedback modal:', error);
+      sendResponse({ success: false, error: error.message });
+    }
+  }
+
+  // v2.10.5: Instant toggle extension on/off (all platforms)
+  if (message.action === 'toggleExtension') {
+    try {
+      const isEnabled = message.enabled;
+      console.log('[AI Compliance Checker] Received toggle message:', isEnabled);
+
+      if (isEnabled) {
+        // Aktiviere Extension
+        if (!complianceMonitor) {
+          complianceMonitor = new ComplianceMonitor();
+        } else {
+          complianceMonitor.startMonitoring();
+        }
+      } else {
+        // Deaktiviere Extension
+        if (complianceMonitor) {
+          complianceMonitor.stopMonitoring();
+        }
+      }
+
+      sendResponse({ success: true, enabled: isEnabled });
+    } catch (error) {
+      console.error('[AI Compliance Checker] Error toggling extension:', error);
       sendResponse({ success: false, error: error.message });
     }
   }

--- a/extension/scripts/version.js
+++ b/extension/scripts/version.js
@@ -5,7 +5,7 @@
  * Update this file when releasing new versions.
  */
 
-export const VERSION = '2.10.4';
+export const VERSION = '2.10.5';
 export const VERSION_LABEL = 'BETA';
 export const VERSION_FULL = `${VERSION} ${VERSION_LABEL}`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-compliance-checker",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Enhanced compliance checker for ChatGPT, Claude, Gemini with Compromise.js NER (ML-quality without ML) - Now with dates, places, money, organizations",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Fixes #issue - Plugin war nur auf ChatGPT deaktivierbar, nicht auf Claude/Gemini

### Problembeschreibung
- Plugin-Deaktivierung über Options-Menü wirkte nur auf ChatGPT
- Claude und Gemini blieben aktiv
- Deaktivierung war nicht instant (Tab-Reload erforderlich)
- Toggle-Switch war versteckt in Einstellungen

### Ursache
- Content-Scripts auf bereits geladenen Tabs erhielten Storage-Änderungen nicht
- chrome.storage.onChanged Listener funktionierte nicht zuverlässig für alle Tabs
- UI: Toggle war nicht prominent sichtbar

### Lösung
1. **Message Broadcasting** (popup.js):
   - Sendet 'toggleExtension' Message an ALLE offenen Tabs
   - Nicht nur aktiver Tab, sondern chrome.tabs.query({})
   - Sofortige Propagierung der Einstellung

2. **Message-Listener** (content.js):
   - Reagiert auf 'toggleExtension' Action
   - Startet/stoppt Monitor instant
   - Globale Monitor-Referenz ermöglicht dynamisches Toggle

3. **Bugfix stopMonitoring()**:
   - Verwendete nicht-existierende 'this.statusIcons' Property
   - Korrigiert zu 'this.globalStatusIcon'
   - Observer wird jetzt korrekt disconnected

4. **UI-Verbesserung**:
   - Toggle-Switch direkt neben Status-Display verschoben
   - Bessere Sichtbarkeit und Zugänglichkeit

### Getestet auf
- ✅ ChatGPT (chat.openai.com, chatgpt.com)
- ✅ Claude (claude.ai)
- ✅ Gemini (gemini.google.com)

### Dateien geändert
- extension/popup.html: Toggle verschoben zu Status-Display
- extension/popup.js: Message Broadcasting implementiert
- extension/scripts/content.js: Message-Listener + stopMonitoring() Fix
- CHANGELOG.md: Version 2.10.5 Details
- README.md: Release Notes aktualisiert
- Version: 2.10.4 → 2.10.5